### PR TITLE
Update G2E STL README.md

### DIFF
--- a/galileo2_extruder/stl/README.md
+++ b/galileo2_extruder/stl/README.md
@@ -14,4 +14,10 @@ For G2E, here is the list of STL files that you need to choose a SINGLE file fro
 * <ins>cable_chain_3_hole.stl</ins>
 	* For 3-hole cable chains (befenybay and similar).
 
+And a SINGLE file from:
+* <ins>front_body_ECAS_coupler.stl</ins>
+	* For installation of an ECAS bowden coupler on the G2E body
+* <ins>front_body.stl</ins>
+	* For a friction fit bowden tube into the G2E body
+
 ![Image](../../images/g2eplate.png)


### PR DESCRIPTION
Updated the G2E README.md to include that only 1 of either front_body_ECAS_coupler.stl or front_body.stl needs to be printed as only the cable chain holders were called out prior. 